### PR TITLE
Code review

### DIFF
--- a/contracts/src/BlockhashOpcodeOracle.sol
+++ b/contracts/src/BlockhashOpcodeOracle.sol
@@ -26,13 +26,6 @@ contract BlockhashOpcodeOracle is IBlockhashOracle {
         poke();
     }
 
-    /// @notice Returns the block number of a validated block hash.
-    /// This doubles as a block hash verifier and a block number oracle.
-    /// @param hash Blockhash being verified.
-    function blockHashToNumber(bytes32 hash) external view returns (uint256) {
-        return blockhashToBlockNum[hash];
-    }
-
     /// @notice Validates the block hash of the block before this tx is called.
     function poke() public {
         uint256 prevBlockNum = block.number - 1;

--- a/contracts/src/IBlockhashOracle.sol
+++ b/contracts/src/IBlockhashOracle.sol
@@ -11,5 +11,5 @@ interface IBlockhashOracle {
 
     /// @notice Returns the nonzero, accurate block number
     /// if the block hash is validated!.
-    function blockHashToNumber(bytes32 hash) external view returns (uint256);
+    function blockhashToBlockNum(bytes32 hash) external view returns (uint256);
 }

--- a/contracts/src/RANDAOProvider.sol
+++ b/contracts/src/RANDAOProvider.sol
@@ -213,7 +213,7 @@ contract RANDAOProvider is Owned, IRandomnessProvider {
 
         // Validate blockhash using block hash oracle.
         bytes32 blockHash = keccak256(rlp);
-        if (blockhashOracle.blockHashToNumber(blockHash) == 0) {
+        if (blockhashOracle.blockhashToBlockNum(blockHash) == 0) {
             revert BlockhashUnverified(blockHash);
         }
 

--- a/contracts/src/utils/RLPReader.sol
+++ b/contracts/src/utils/RLPReader.sol
@@ -3,7 +3,6 @@
 /**
  * @author Hamdi Allam hamdi.allam97@gmail.com
  * Please reach out with any questions or concerns
- *
  */
 pragma solidity ^0.8.16;
 

--- a/contracts/test/BlockhashOpcodeOracle.t.sol
+++ b/contracts/test/BlockhashOpcodeOracle.t.sol
@@ -29,7 +29,7 @@ contract BlockhashOpcodeOracleTest is Test {
         emit BlockhashValidated(99, pokedBlockhash);
 
         BlockhashOpcodeOracle oracle = new BlockhashOpcodeOracle();
-        assertEq(oracle.blockHashToNumber(pokedBlockhash), 99);
+        assertEq(oracle.blockhashToBlockNum(pokedBlockhash), 99);
     }
 
     /// @notice Tests that poking attests to the previous block's block hash.
@@ -70,6 +70,6 @@ contract BlockhashOpcodeOracleTest is Test {
 
     /// @notice Wrapper function that determines if a block hash is valid.
     function isValidBlockhash(bytes32 blockHash) internal view returns (bool) {
-        return blockhashOracle.blockHashToNumber(blockHash) != 0;
+        return blockhashOracle.blockhashToBlockNum(blockHash) != 0;
     }
 }

--- a/contracts/test/RandomnessProvider.t.sol
+++ b/contracts/test/RandomnessProvider.t.sol
@@ -258,7 +258,7 @@ contract RANDAOOracleTest is Test {
 
     /// @notice Mocks the block hash oracle's response for a validity check.
     function mockOracle(bytes32 blockHash, uint256 response) internal {
-        stdstore.target(address(blockhashOracle)).sig("blockHashToNumber(bytes32)").with_key(blockHash).checked_write(
+        stdstore.target(address(blockhashOracle)).sig("blockhashToBlockNum(bytes32)").with_key(blockHash).checked_write(
             response
         );
     }

--- a/contracts/test/ZKBlockhashOracle.t.sol
+++ b/contracts/test/ZKBlockhashOracle.t.sol
@@ -244,15 +244,15 @@ contract ZKBlockhashOracleTest is Test {
         zkBlockhashOracle = new ZKBlockhashOracle();
     }
 
-    /// @notice Tests that a proof validates  within blockhash opcode range.
+    /// @notice Tests that a proof validates within blockhash opcode range.
     function testCanVerifyValidProofInBlockhashOpcodeRange() public {
         uint256 testBlock = proofBlockNumber + 256;
         vm.roll(testBlock);
 
         // Both proof's block hash and parent blockhash are not be verified before the proof.
-        uint256 unverifiedBlockNumber = zkBlockhashOracle.blockHashToNumber(proofBlockHash);
+        uint256 unverifiedBlockNumber = zkBlockhashOracle.blockhashToBlockNum(proofBlockHash);
         assertEq(unverifiedBlockNumber, 0);
-        uint256 unVerifiedParentBlockNumber = zkBlockhashOracle.blockHashToNumber(proofParentHash);
+        uint256 unVerifiedParentBlockNumber = zkBlockhashOracle.blockhashToBlockNum(proofParentHash);
         assertEq(unVerifiedParentBlockNumber, 0);
 
         // TODO(aman): Figure out how to mock blockhash opcode itself instead of contract storage.
@@ -263,9 +263,9 @@ contract ZKBlockhashOracleTest is Test {
         assertTrue(verified);
 
         // Both proof's block hash and parent blockhash are verified.
-        uint256 verifiedBlockNumber = zkBlockhashOracle.blockHashToNumber(proofBlockHash);
+        uint256 verifiedBlockNumber = zkBlockhashOracle.blockhashToBlockNum(proofBlockHash);
         assertTrue(verifiedBlockNumber != 0); // TODO(aman): Change this after mocking blockhash opcode.
-        uint256 verifiedParentBlockNumber = zkBlockhashOracle.blockHashToNumber(proofParentHash);
+        uint256 verifiedParentBlockNumber = zkBlockhashOracle.blockhashToBlockNum(proofParentHash);
         assertEq(verifiedParentBlockNumber, proofBlockNumber - 1);
     }
 
@@ -308,7 +308,7 @@ contract ZKBlockhashOracleTest is Test {
 
     /// @notice Mocks the block hash oracle's response for a validity check.
     function mockBlockhashOracle(bytes32 blockHash, uint256 response) internal {
-        stdstore.target(address(zkBlockhashOracle)).sig("blockHashToNumber(bytes32)").with_key(blockHash).checked_write(
+        stdstore.target(address(zkBlockhashOracle)).sig("blockhashToBlockNum(bytes32)").with_key(blockHash).checked_write(
             response
         );
     }


### PR DESCRIPTION
Small nits from a quick code review.

Biggest thing is that, for `blockhashToBlockNum`, since we have it as a public state variable, we don't need to manually reimplement a getter for it to adhere to the interface.